### PR TITLE
Update URLs after repo rename to websum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,4 +39,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First public scripts under `app/` using LangChain + ChatOllama.
 - Gradio UI, web page and YouTube summarization, Turkish translation.
 
-[0.2.0]: https://github.com/mertcobanov/easy-web-summarizer/releases/tag/v0.2.0
+[0.2.0]: https://github.com/cobanov/websum/releases/tag/v0.2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ Thanks for your interest in improving websum. This document covers the dev setup
 Requirements: Python 3.10+ and [uv](https://docs.astral.sh/uv/).
 
 ```bash
-git clone https://github.com/mertcobanov/easy-web-summarizer
-cd easy-web-summarizer
+git clone https://github.com/cobanov/websum
+cd websum
 uv sync --all-extras
 uv run pre-commit install
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # websum
 
-[![CI](https://github.com/mertcobanov/easy-web-summarizer/actions/workflows/ci.yml/badge.svg)](https://github.com/mertcobanov/easy-web-summarizer/actions/workflows/ci.yml)
+[![CI](https://github.com/cobanov/websum/actions/workflows/ci.yml/badge.svg)](https://github.com/cobanov/websum/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/pypi/pyversions/websum.svg)](https://pypi.org/project/websum/)
 [![PyPI](https://img.shields.io/pypi/v/websum.svg)](https://pypi.org/project/websum/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
@@ -123,8 +123,8 @@ The 0.1.x scripts under `app/` (`summarizer.py`, `translator.py`, `yt_summarizer
 ## Development
 
 ```bash
-git clone https://github.com/mertcobanov/easy-web-summarizer
-cd easy-web-summarizer
+git clone https://github.com/cobanov/websum
+cd websum
 uv sync --all-extras
 uv run pre-commit install
 uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,10 +56,10 @@ dev = [
 websum = "websum.cli:app"
 
 [project.urls]
-Homepage = "https://github.com/mertcobanov/easy-web-summarizer"
-Repository = "https://github.com/mertcobanov/easy-web-summarizer"
-Issues = "https://github.com/mertcobanov/easy-web-summarizer/issues"
-Changelog = "https://github.com/mertcobanov/easy-web-summarizer/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/cobanov/websum"
+Repository = "https://github.com/cobanov/websum"
+Issues = "https://github.com/cobanov/websum/issues"
+Changelog = "https://github.com/cobanov/websum/blob/main/CHANGELOG.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/websum"]


### PR DESCRIPTION
## Summary

- Repo renamed on GitHub from `easy-web-summarizer` to `websum` (URL: https://github.com/cobanov/websum) so it matches the PyPI package name.
- Update `pyproject.toml` project URLs (Homepage, Repository, Issues, Changelog).
- Update README badge URLs and clone instructions.
- Update CONTRIBUTING clone instructions.
- Update CHANGELOG 0.2.0 release tag link.

GitHub keeps automatic redirects from the old `mertcobanov/easy-web-summarizer` and `cobanov/easy-web-summarizer` URLs, so existing stars, issues, and bookmarks continue to resolve.

## Test plan

- [x] `grep` confirms no stale `easy-web-summarizer` or `mertcobanov/` URL refs remain in markdown / toml / yaml / py
- [ ] CI passes on the PR