### PR TITLE
Bump langchain-core and langchain-community version ceilings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
 ]
 dependencies = [
     "langchain>=0.3,<1.4",
-    "langchain-core>=0.3,<0.4",
-    "langchain-community>=0.3,<0.4",
+    "langchain-core>=0.3,<1.5",
+    "langchain-community>=0.3,<0.5",
     "langchain-text-splitters>=0.3,<1.2",
     "beautifulsoup4>=4.12",
     "youtube-transcript-api>=0.6",

--- a/uv.lock
+++ b/uv.lock
@@ -681,7 +681,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -3546,14 +3546,14 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "gradio", marker = "extra == 'all'", specifier = ">=4.40" },
     { name = "gradio", marker = "extra == 'ui'", specifier = ">=4.40" },
-    { name = "langchain", specifier = ">=0.3,<0.4" },
-    { name = "langchain-community", specifier = ">=0.3,<0.4" },
-    { name = "langchain-core", specifier = ">=0.3,<0.4" },
+    { name = "langchain", specifier = ">=0.3,<1.4" },
+    { name = "langchain-community", specifier = ">=0.3,<0.5" },
+    { name = "langchain-core", specifier = ">=0.3,<1.5" },
     { name = "langchain-ollama", marker = "extra == 'all'", specifier = ">=0.2" },
     { name = "langchain-ollama", marker = "extra == 'ollama'", specifier = ">=0.2" },
     { name = "langchain-openai", marker = "extra == 'all'", specifier = ">=0.2" },
     { name = "langchain-openai", marker = "extra == 'openai'", specifier = ">=0.2" },
-    { name = "langchain-text-splitters", specifier = ">=0.3,<0.4" },
+    { name = "langchain-text-splitters", specifier = ">=0.3,<1.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },


### PR DESCRIPTION
## Summary

Bumps the version ceilings on two LangChain packages. Combines dependabot PRs #15 and #16 into a single PR because they both touch the same area of `pyproject.toml` and cannot be merged sequentially without a manual rebase.

- `langchain-core`: `>=0.3,<0.4` -> `>=0.3,<1.5` (was #16)
- `langchain-community`: `>=0.3,<0.4` -> `>=0.3,<0.5` (was #15)

Closes #15
Closes #16

## Test plan

- [x] `uv lock` resolves cleanly
- [ ] CI passes (lint, type-check, test 3.10-3.13, build)