### PR TITLE
Fix stale PyPI badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # websum
 
 [![CI](https://github.com/cobanov/websum/actions/workflows/ci.yml/badge.svg)](https://github.com/cobanov/websum/actions/workflows/ci.yml)
-[![Python](https://img.shields.io/pypi/pyversions/websum.svg)](https://pypi.org/project/websum/)
-[![PyPI](https://img.shields.io/pypi/v/websum.svg)](https://pypi.org/project/websum/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![PyPI](https://img.shields.io/pypi/v/websum?style=flat-square&cacheSeconds=300)](https://pypi.org/project/websum/)
+[![Python](https://img.shields.io/pypi/pyversions/websum?style=flat-square&cacheSeconds=300)](https://pypi.org/project/websum/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
 
 Summarize web pages and YouTube videos with pluggable LLM backends. Ships with first-class support for **Ollama** (local) and **OpenAI**, plus an optional Gradio web UI.
 


### PR DESCRIPTION
## Summary

The shields.io PyPI badges were rendering as \"package or version not found\" because shields.io fetched them before the 0.2.0 PyPI release was published and cached the negative response for 3-6 hours.

Adding `?style=flat-square&cacheSeconds=300` to the badge URLs changes the cache key so shields.io fetches fresh data immediately, and future caches expire after 5 minutes instead of hours.

Verified the new URLs return the correct content:

- PyPI badge: `pypi: v0.2.0`
- Python badge: `python: 3.10 | 3.11 | 3.12 | 3.13`

## Test plan

- [x] `curl` the new badge URLs and confirm correct SVG content
- [ ] Render the README on GitHub after merge and confirm both badges show green/orange instead of red \"not found\"